### PR TITLE
Propagate errors from AbstractListenableAdapter.initialize()

### DIFF
--- a/runtime/src/main/java/com/leaprnd/observer4j/AbstractListenableAdapter.java
+++ b/runtime/src/main/java/com/leaprnd/observer4j/AbstractListenableAdapter.java
@@ -21,7 +21,13 @@ public abstract class AbstractListenableAdapter<T> extends AbstractListenable<T>
 	}
 
 	protected final void initialize() {
-		executor.execute(() -> initialize(build(listener)));
+		executor.execute(() -> {
+			try {
+				initialize(build(listener));
+			} catch (Throwable exception) {
+				initialize(exception);
+			}
+		});
 	}
 
 	protected abstract T build(Listener<Object> listener);


### PR DESCRIPTION
These changes fix an bug in `AbstractListenableAdapter` where if `build()` threw an exception, then any threads blocking inside `waitUntilInitializedToGetState()` would wait forever.